### PR TITLE
Fix ssl protocol error when sonoff basic tries to connect to the torn…

### DIFF
--- a/sonota.py
+++ b/sonota.py
@@ -25,6 +25,7 @@ import os
 import sys
 import threading
 import _thread
+import ssl
 from datetime import datetime
 from hashlib import sha256
 from httplib2 import Http
@@ -655,6 +656,7 @@ def stage2():
     app_ssl = tornado.httpserver.HTTPServer(app, ssl_options={
         "certfile": resource_path("ssl/server.crt"),
         "keyfile": resource_path("ssl/server.key"),
+        "ssl_version": ssl.PROTOCOL_TLSv1_1,
     })
     # listening on HTTPS port to catch initial POST request to eu-disp.coolkit.cc
     app_ssl.listen(DEFAULT_PORT_HTTPS)


### PR DESCRIPTION
…ado server on debian

This enables TLSv1.1 support for the tornado https server which the sonoff
tries to connect to. TLSv1.1 is insecure and therefore disabled by default
by most modern packages.
But it seems the sonoff firmware can only do TLSv1.1
Without this I got a ssl protocol error and I could not move to FinalStage.